### PR TITLE
Fix Django 5.0 compatibility

### DIFF
--- a/rest_live/__init__.py
+++ b/rest_live/__init__.py
@@ -1,5 +1,3 @@
-default_app_config = "rest_live.apps.RestLiveConfig"
-
 DEFAULT_GROUP_BY_FIELD = "pk"
 
 

--- a/rest_live/mixins.py
+++ b/rest_live/mixins.py
@@ -4,7 +4,6 @@ from typing import Type, Set, Tuple, Dict, Any, Optional
 from django.core.handlers.asgi import ASGIRequest
 from django.db.models import Model
 from django.db.models.signals import post_save, post_delete
-from django.utils.decorators import classonlymethod
 from django.utils.http import urlencode
 from rest_framework.generics import GenericAPIView
 from rest_live.signals import delete_handler, save_handler
@@ -50,7 +49,7 @@ class RealtimeMixin(object):
         post_delete.connect(delete_handler, sender=model_class, dispatch_uid=f"rest-live")
         return viewset.get_model_class()._meta.label
 
-    @classonlymethod
+    @classmethod
     def from_scope(cls, viewset_action, scope, view_kwargs, query_params):
         """
         "This is the magic."


### PR DESCRIPTION
Remove deprecated default_app_config (removed in Django 5.0) and replace classonlymethod with classmethod (private API removed in Django 5.0).